### PR TITLE
Update BSlogger.hpp

### DIFF
--- a/src/BSlogger.hpp
+++ b/src/BSlogger.hpp
@@ -227,7 +227,7 @@ void logger::time_since_start()
 
 void logger::time_since_last_snap()
 {
-  if (_loglevel() >= LOG_TIME)
+  if (_loglevel() >= LOG_TIME && _snap_ns.size() > 0)
   {
     time(&_now);
     _message_level = LOG_TIME;
@@ -244,6 +244,12 @@ void logger::time_since_snap(std::string s)
   {
     time(&_now);
     auto it = find(_snap_ns.begin(), _snap_ns.end(), s);
+    if (it == _snap_ns.end()){
+        _message_level = LOG_WARN;
+        _fac << prep_level(*this) << prep_time(*this) <<
+             prep_name(*this) << ": " << "Could not find snapshot " << s << '\n';
+        return;
+    }
     unsigned long dist = std::distance(_snap_ns.begin(), it);
 
     _message_level = LOG_TIME;


### PR DESCRIPTION
Hi, this is my first ever pull request. I am using your logger and stumbled upon this "bug":

Fixes unhandled exception on erroneous usage of snapshots.
Try this program to see the exceptions:

#include "src/BSlogger.hpp"
#include <unistd.h>

int main()
{
    LOG_INIT_CERR();
    log.set_log_level(LOG_DEBUG);

    log(LOG_DEBUG) << "Some text\n";
    log.time_since_last_snap();
    //log.time_since_snap("BB");
    //log.add_snapshot("AA");

    return 0;
}
